### PR TITLE
[refactor] #136 Edit IngredientsAllBtn, when go back and forth betwee…

### DIFF
--- a/app/src/main/java/com/afume/afume_android/ui/filter/FilterViewModel.kt
+++ b/app/src/main/java/com/afume/afume_android/ui/filter/FilterViewModel.kt
@@ -48,7 +48,6 @@ class FilterViewModel : ViewModel() {
         getBrand()
         getSeries()
         getKeyword()
-
         badgeCount.value = mutableListOf(0, 0, 0)
     }
 
@@ -110,7 +109,7 @@ class FilterViewModel : ViewModel() {
     fun blockClickKeywordMoreThan5() {
         val tempList = keywordList.value
         if (badgeCount.value?.get(2)!! >= 5) {
-            Log.e("count", badgeCount.value?.get(2).toString())
+            Log.d("count", badgeCount.value?.get(2).toString())
             tempList?.forEach {
                 val keyword = it
                 keyword.clickable = false
@@ -286,6 +285,7 @@ class FilterViewModel : ViewModel() {
             val keywordInfoP = FilterInfoP(it.keywordIdx, it.name, 3)
             filterInfoPList.add(keywordInfoP)
         }
+
         return SendFilter(filterInfoPList, selectedSeriesMap.value)
     }
 
@@ -312,7 +312,7 @@ class FilterViewModel : ViewModel() {
         selectedKeywordList.value = keyword
         badgeCount.value?.set(2, keyword.size)
 
-        Log.e("change filter", selectedSeriesMap.value.toString())
+        Log.d("change filter", selectedSeriesMap.value.toString())
 
         // 뱃지 카운트 재정비
         getTotalBadgeCount()

--- a/app/src/main/java/com/afume/afume_android/ui/filter/incense/IngredientFlexboxAdapter.kt
+++ b/app/src/main/java/com/afume/afume_android/ui/filter/incense/IngredientFlexboxAdapter.kt
@@ -40,7 +40,7 @@ class IngredientFlexboxAdapter(
 
     inner class IngredientFlexboxHolder(val binding: RvItemSeriesIngredientsFilterBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        private lateinit var changeList :MutableList<SeriesIngredients>
+        private lateinit var changeList: MutableList<SeriesIngredients>
         var selectedIngredients = mutableListOf<SeriesIngredients>()
 
         fun bind(data: SeriesIngredients) {
@@ -48,9 +48,24 @@ class IngredientFlexboxAdapter(
             initSelectedIngredients()
             Log.d("ingredients data", data.toString())
 
+            // 그려줄때, 전체가 선택 되어있는 경우 다른 재료들 비활성화
+            if (data.checked && data.ingredientIdx <= -1) { //전체를 선택했을 경우
+//                    setInactiveAll()
+                changeList = currentList
+                for (i in 1..currentList.lastIndex) {
+                    if (changeList[i].checked) {
+                        changeList[i].checked = false
+                    }
+                }
+            }
+
             binding.root.setOnClickListener { it ->
-                Log.e("ingredientIdx",data.ingredientIdx.toString())
-                if(!data.clickable) Toast.makeText(it.context, "5개 이상 선택 할 수 없어요.", Toast.LENGTH_SHORT).show()
+                Log.e("ingredientIdx", data.ingredientIdx.toString())
+                if (!data.clickable) Toast.makeText(
+                    it.context,
+                    "5개 이상 선택 할 수 없어요.",
+                    Toast.LENGTH_SHORT
+                ).show()
                 else {
                     data.checked = !data.checked
                     if (data.ingredientIdx <= -1) { //전체를 선택했을 경우
@@ -58,42 +73,42 @@ class IngredientFlexboxAdapter(
                         // 전체선택 활성화, 모든 버튼 비활성화 후 인덱스 리스트에 추가
                         if (data.checked) {
                             setInactiveAll()
+                            Log.d("스파이시 전체", ingredientsList.toString())
                             ingredientsList.forEach { selectedIngredients.add(it) }
                             countBadge(0, true)
                         }
                         // 전체선택 비활성화
                         else setInactiveEntire()
-                    }
-                    else { // 전체가 아닌 하나의 ingredient를 선택했을 때 선택한 인덱스 추가
+                    } else { // 전체가 아닌 하나의 ingredient를 선택했을 때 선택한 인덱스 추가
                         if (data.checked) {
                             // 전체 선택이 되어 있는 경우, 전체 선택 비활성화
                             if (currentList[0].checked) setInactiveEntire()
 
                             selectedIngredients.add(data)
                             countBadge(0, true)
-                        }
-                        else {
+                        } else {
                             selectedIngredients.remove(data)
                             countBadge(0, false)
                         }
                     }
 
                     // viewModel로 selectedIngredients 넘기기
-                    setSelectedIngredients(data.seriesName+" 전체", selectedIngredients)
+                    setSelectedIngredients(data.seriesName + " 전체", selectedIngredients)
                     Log.e("selectedIngredients__", selectedIngredients.toString())
                 }
             }
 
         }
 
-        fun initSelectedIngredients(){
+        fun initSelectedIngredients() {
             selectedIngredients.clear()
-            changeList=currentList
+            changeList = currentList
             changeList.forEach {
-                if(it.checked) selectedIngredients.add(it)
+                if (it.checked) selectedIngredients.add(it)
             }
         }
-        fun setInactiveEntire(){
+
+        fun setInactiveEntire() {
             //계열 전체 버튼 비활성화
             changeList = currentList
             changeList[0].checked = false
@@ -101,13 +116,14 @@ class IngredientFlexboxAdapter(
             countBadge(0, false)
             selectedIngredients.clear()
         }
-        fun setInactiveAll(){
+
+        fun setInactiveAll() {
             //각 계열의 모든 버튼 비활성화
             changeList = currentList
             for (i in 1..currentList.lastIndex) {
-                if(changeList[i].checked) {
+                if (changeList[i].checked) {
                     changeList[i].checked = false
-                    countBadge(0,false)
+                    countBadge(0, false)
                 }
             }
 //            setList(changeList)

--- a/app/src/main/java/com/afume/afume_android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/afume/afume_android/ui/search/SearchViewModel.kt
@@ -40,7 +40,7 @@ class SearchViewModel : ViewModel() {
             tempFilterList?.forEach {
                 when (it.type) {
                     1 -> {
-                        if (it.idx != -1) requestSearch.ingredientList?.add(it.idx)
+                        if (it.idx > -1) requestSearch.ingredientList?.add(it.idx)
                         else {
                             filter.value?.filterSeriesPMap?.get(it.name)?.forEach {
                                 requestSearch.ingredientList?.add(it.ingredientIdx)
@@ -69,7 +69,7 @@ class SearchViewModel : ViewModel() {
     fun cancelBtnFilter(f: FilterInfoP?) {
         var tmpFilter =filter.value;
         if (f != null) {
-            if (f.idx == -1) tmpFilter?.filterSeriesPMap?.get(f.name)?.clear()
+            if (f.idx <= -1) tmpFilter?.filterSeriesPMap?.remove(f.name)
             else {
 
                 if (f.type == 1) tmpFilter?.filterSeriesPMap?.values?.forEach { list ->


### PR DESCRIPTION
Edit IngredientsAllBtn, when go back and forth between filter view and search view


필터 뷰에서 게열 전체 버튼(예를 들어 시트러스 전체) 클릭 후 , 
검색 결과에서 시트러스 전체 버튼 취소 후 다시 필터 뷰로 왔을 때, 
- 시트러스 전체 버튼을 뺀 모든 버튼이 활성화 되어 있던 버그 해결
- 뱃지에 값이 0으로 다시 초기화 되는 버그 해결

