### PR TITLE
[chore] upgrade gradle

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,11 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
-        <option name="disableWrapperSourceDistributionNotification" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -18,8 +17,6 @@
             <option value="$PROJECT_DIR$/scents_note_ui_sample" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'com.google.gms.google-services'
+    id 'androidx.navigation.safeargs.kotlin'
 }
 
 android {
@@ -27,11 +28,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         <activity android:name="com.scentsnote.android.util.BaseWebViewActivity" />
         <activity
             android:name="com.scentsnote.android.ui.splash.SplashActivity"
+            android:exported="true"
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/scentsnote/android/ui/filter/FilterViewModelFactory.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/filter/FilterViewModelFactory.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
 class FilterViewModelFactory : ViewModelProvider.NewInstanceFactory(){
-    override fun <T : ViewModel?> create(modelClass: Class<T>) =
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
         with(modelClass) {
             when {
                 isAssignableFrom(FilterViewModel::class.java) -> FilterViewModel.getInstance()

--- a/app/src/main/java/com/scentsnote/android/ui/search/SingleViewModelFactory.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/search/SingleViewModelFactory.kt
@@ -12,7 +12,7 @@ class SingleViewModelFactory : ViewModelProvider.NewInstanceFactory() {
         }
     }
 
-    override fun <T : ViewModel?> create(modelClass: Class<T>) =
+    override fun <T : ViewModel> create(modelClass: Class<T>): T =
         with(modelClass) {
             when {
                 isAssignableFrom(SearchViewModel::class.java) -> SearchViewModel.getInstance()

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import kotlin.Suppress
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
@@ -11,6 +9,8 @@ buildscript {
         jcenter()
     }
     dependencies {
+
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${ConfigData.nav_version}")
         classpath "com.android.tools.build:gradle:${ConfigData.gradleVersion}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${ConfigData.gradlePluginVersion}"
         classpath "com.google.gms:google-services:${Versions.gms}"

--- a/buildSrc/src/main/java/ConfigData.kt
+++ b/buildSrc/src/main/java/ConfigData.kt
@@ -1,15 +1,18 @@
 object ConfigData {
-    const val compileSdkVersion = 30
-    const val buildToolsVersion = "30.0.0"
+    const val compileSdkVersion = 31
+    const val buildToolsVersion = "30.0.3"
     const val minSdkVersion = 23
-    const val targetSdkVersion = 30
+    const val targetSdkVersion = 31
     const val versionCode = 1
     const val versionName = "1.0"
 
     // gradle
-    const val gradleVersion = "4.1.1"
-    const val gradlePluginVersion = "1.5.31"
+    const val gradleVersion = "7.3.1"
+    const val gradlePluginVersion = "1.7.20"
 
     // kotlin
     const val kotlin_version = "1.4.20"
+
+    // navigation
+    const val nav_version = "2.5.3"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -19,9 +19,9 @@ object Dependencies {
 
     /* android.arch */
     const val navigationFragmentKtx =
-        "android.arch.navigation:navigation-fragment-ktx:${Versions.navigationKtx}"
+        "androidx.navigation:navigation-fragment-ktx:${Versions.navigationKtx}"
     const val navigationUiKtx =
-        "android.arch.navigation:navigation-ui-ktx:${Versions.navigationKtx}"
+        "androidx.navigation:navigation-ui-ktx:${Versions.navigationKtx}"
 
     /* retrofit2 : https://github.com/square/retrofit */
     const val retrofit2 = "com.squareup.retrofit2:retrofit:${Versions.retrofit2}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -37,7 +37,7 @@ object Versions {
     const val glide = "4.11.0"
 
     // navigation
-    const val navigationKtx = "2.2.2"
+    const val navigationKtx = "2.5.3"
 
     // flexbox
     const val flexbox = "2.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
플레이스토어 등록 기준 변경(타켓팅 API 수준 31 이상)에 따라 gradle 업그레이드 진행

- gradle : 4.1.1 -> 7.3.1
- gradle plugin : 1.5.31 -> 1.7.20

- compile Sdk : 30 -> 31
- target SDK : 30 -> 31

- JDK : 1.8 -> 11

- nvigationKtx : 2.2.2 -> 2.5.3
- navigation classpath 추가(version : 2.5.3)